### PR TITLE
Fix forward declarations

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -588,6 +588,10 @@ bool CacheShard::removeFileEntries(
 }
 
 AsyncDataCache::AsyncDataCache(
+    memory::MemoryAllocator* allocator)
+    : AsyncDataCache(allocator, nullptr) {}
+
+AsyncDataCache::AsyncDataCache(
     memory::MemoryAllocator* allocator,
     std::unique_ptr<SsdCache> ssdCache)
     : allocator_(allocator), ssdCache_(std::move(ssdCache)), cachedPages_(0) {
@@ -605,6 +609,11 @@ std::shared_ptr<AsyncDataCache> AsyncDataCache::create(
   auto cache = std::make_shared<AsyncDataCache>(allocator, std::move(ssdCache));
   allocator->registerCache(cache);
   return cache;
+}
+
+std::shared_ptr<AsyncDataCache> AsyncDataCache::create(
+    memory::MemoryAllocator* allocator) {
+      return AsyncDataCache::create(allocator, nullptr);
 }
 
 // static

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -661,14 +661,19 @@ class CacheShard {
 class AsyncDataCache : public memory::Cache {
  public:
   AsyncDataCache(
-      memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      memory::MemoryAllocator* allocator);
+  AsyncDataCache(
+      memory::MemoryAllocator* allocator, std::unique_ptr<SsdCache> ssdCache);
 
   ~AsyncDataCache() override;
 
+
+  static std::shared_ptr<AsyncDataCache> create(
+      memory::MemoryAllocator* allocator);
+
   static std::shared_ptr<AsyncDataCache> create(
       memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      std::unique_ptr<SsdCache> ssdCache);
 
   static AsyncDataCache* getInstance();
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -37,7 +37,71 @@ class Config;
 
 namespace facebook::velox::connector {
 
-class DataSource;
+struct ConnectorSplit;
+
+class DataSource {
+ public:
+  static constexpr int64_t kUnknownRowSize = -1;
+  virtual ~DataSource() = default;
+
+  // Add split to process, then call next multiple times to process the split.
+  // A split must be fully processed by next before another split can be
+  // added. Next returns nullptr to indicate that current split is fully
+  // processed.
+  virtual void addSplit(std::shared_ptr<ConnectorSplit> split) = 0;
+
+  // Process a split added via addSplit. Returns nullptr if split has been fully
+  // processed. Returns std::nullopt and sets the 'future' if started
+  // asynchronous work and needs to wait for it to complete to continue
+  // processing. The caller will wait for the 'future' to complete before
+  // calling 'next' again.
+  virtual std::optional<RowVectorPtr> next(
+      uint64_t size,
+      velox::ContinueFuture& future) = 0;
+
+  // Add dynamically generated filter.
+  // @param outputChannel index into outputType specified in
+  // Connector::createDataSource() that identifies the column this filter
+  // applies to.
+  virtual void addDynamicFilter(
+      column_index_t outputChannel,
+      const std::shared_ptr<common::Filter>& filter) = 0;
+
+  // Returns the number of input bytes processed so far.
+  virtual uint64_t getCompletedBytes() = 0;
+
+  // Returns the number of input rows processed so far.
+  virtual uint64_t getCompletedRows() = 0;
+
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+
+  // Returns true if 'this' has initiated all the prefetch this will
+  // initiate. This means that the caller should schedule next splits
+  // to prefetch in the background. false if the source does not
+  // prefetch.
+  virtual bool allPrefetchIssued() const {
+    return false;
+  }
+
+  // Initializes this from 'source'. 'source' is effectively moved
+  // into 'this' Adaptation like dynamic filters stay in effect but
+  // the parts dealing with open files, prefetched data etc. are moved. 'source'
+  // is freed after the move.
+  virtual void setFromDataSource(std::unique_ptr<DataSource> /*source*/) {
+    VELOX_UNSUPPORTED("setFromDataSource");
+  }
+
+  // Returns a connector dependent row size if available. This can be
+  // called after addSplit().  This estimates uncompressed data
+  // sizes. This is better than getCompletedBytes()/getCompletedRows()
+  // since these track sizes before decompression and may include
+  // read-ahead and extra IO from coalescing reads and  will not
+  // fully account for size of sparsely accessed columns.
+  virtual int64_t estimatedRowSize() {
+    return kUnknownRowSize;
+  }
+};
+
 
 // A split represents a chunk of data that a connector should load and return
 // as a RowVectorPtr, potentially after processing pushdowns.
@@ -163,69 +227,6 @@ class DataSink {
   /// Called to abort this data sink object and we don't expect any appendData()
   /// calls on an aborted data sink object.
   virtual void abort() = 0;
-};
-
-class DataSource {
- public:
-  static constexpr int64_t kUnknownRowSize = -1;
-  virtual ~DataSource() = default;
-
-  // Add split to process, then call next multiple times to process the split.
-  // A split must be fully processed by next before another split can be
-  // added. Next returns nullptr to indicate that current split is fully
-  // processed.
-  virtual void addSplit(std::shared_ptr<ConnectorSplit> split) = 0;
-
-  // Process a split added via addSplit. Returns nullptr if split has been fully
-  // processed. Returns std::nullopt and sets the 'future' if started
-  // asynchronous work and needs to wait for it to complete to continue
-  // processing. The caller will wait for the 'future' to complete before
-  // calling 'next' again.
-  virtual std::optional<RowVectorPtr> next(
-      uint64_t size,
-      velox::ContinueFuture& future) = 0;
-
-  // Add dynamically generated filter.
-  // @param outputChannel index into outputType specified in
-  // Connector::createDataSource() that identifies the column this filter
-  // applies to.
-  virtual void addDynamicFilter(
-      column_index_t outputChannel,
-      const std::shared_ptr<common::Filter>& filter) = 0;
-
-  // Returns the number of input bytes processed so far.
-  virtual uint64_t getCompletedBytes() = 0;
-
-  // Returns the number of input rows processed so far.
-  virtual uint64_t getCompletedRows() = 0;
-
-  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
-
-  // Returns true if 'this' has initiated all the prefetch this will
-  // initiate. This means that the caller should schedule next splits
-  // to prefetch in the background. false if the source does not
-  // prefetch.
-  virtual bool allPrefetchIssued() const {
-    return false;
-  }
-
-  // Initializes this from 'source'. 'source' is effectively moved
-  // into 'this' Adaptation like dynamic filters stay in effect but
-  // the parts dealing with open files, prefetched data etc. are moved. 'source'
-  // is freed after the move.
-  virtual void setFromDataSource(std::unique_ptr<DataSource> /*source*/) {
-    VELOX_UNSUPPORTED("setFromDataSource");
-  }
-
-  // Returns a connector dependent row size if available. This can be
-  // called after addSplit().  This estimates uncompressed data
-  // sizes. This is better than getCompletedBytes()/getCompletedRows()
-  // since these track sizes before decompression and may include
-  // read-ahead and extra IO from coalescing reads and  will not
-  // fully account for size of sparsely accessed columns.
-  virtual int64_t estimatedRowSize() {
-    return kUnknownRowSize;
-  }
 };
 
 /// Collection of context data for use in a DataSource or DataSink. One instance


### PR DESCRIPTION
Forward declarations cannot be used with smart pointers that are used as arguments with default values or as struct/class members, as the destructor is ill-formed. Found two places where this issue caused velox to fail to compile:

1. `ConnectorSplit` contained a unique_ptr to the underlying `DataSource`. Fixed by moving the `DataSource` declaration first and forward-declaraing the `ConnectorSplit`
2. The `AsyncDataCache` optionally takes a `std::unique_ptr<SsdCache>`, which was forward declared. Replaced the default argument in the initializer and `create` function with overloads.